### PR TITLE
Update Docker build instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,12 +46,12 @@ sudo python3 -m pip install adsbcot
 
 ## Docker
 
-Build the docker container.
+Build the docker container. (The Dockerfile resides in the `docker/` directory.)
 
 ```sh linenums="1"
 git clone https://github.com/snstac/adsbcot.git
 cd adsbcot/
-docker build -t adsbcot .
+docker build -t adsbcot -f docker/Dockerfile .
 ```
 
 Run the docker container with config folder mounted locally. Config files can be edited in the local folder ```/opt/docker/adsbcot/```.


### PR DESCRIPTION
## Summary
- fix docker build command in docs/installation.md
- mention Dockerfile location

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'adsbcot')*

------
https://chatgpt.com/codex/tasks/task_e_685eeba0a484832188dc4ce2c1f8e6e9