### PR TITLE
Fix docker build command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,12 +46,12 @@ sudo python3 -m pip install adsbcot
 
 ## Docker
 
-Build the docker container.
+Build the docker container using the Dockerfile in the `docker` folder.
 
 ```sh linenums="1"
 git clone https://github.com/snstac/adsbcot.git
 cd adsbcot/
-docker build -t adsbcot .
+docker build -t adsbcot -f docker/Dockerfile .
 ```
 
 Run the docker container with config folder mounted locally. Config files can be edited in the local folder ```/opt/docker/adsbcot/```.


### PR DESCRIPTION
## Summary
- explain how to build the docker container from the `docker` folder

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_685eeac8c8c48321a56a666601d1a1a7